### PR TITLE
Failure to specify 'nameservers' should produce an error message.

### DIFF
--- a/src/plugins/modules/zone.py
+++ b/src/plugins/modules/zone.py
@@ -1384,7 +1384,19 @@ def main():
         if props["kind"] in ["Native", "Master", "Producer"]:
             if not props["soa"]:
                 module.fail_json(
-                    msg="'properties -> soa' must be specified for zone creation",
+                    msg=(
+                        f"'properties -> soa' must be specified for '{zone_info['kind']}' zone"
+                        " creation"
+                    ),
+                    **result,
+                )
+
+            if not props["nameservers"]:
+                module.fail_json(
+                    msg=(
+                        f"'properties -> nameservers' must be specified for '{zone_info['kind']}'"
+                        " zone creation"
+                    ),
                     **result,
                 )
 


### PR DESCRIPTION
When a zone is being created and the kind requires nameservers to be specified, generate an error message if the user has not provided them (rather than causing the module to crash.)

Also improve the existing message for missing 'soa' to include the kind of zone being created.

Closes #133.