### PR TITLE
Try to fix zone delegation, by allowing to specifiy record type == NS in rrsets array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ for emergencies).
 
 - Removed support for Python 3.8.
 
+- Fix ability to make zone deligation
+
 ## [24.1.0] - 2024-02-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ for emergencies).
 
 ## [Unreleased]
 
+### Changed
+
+- Allow NS records in RRsets (contributed by torstehu in PR #162).
+
 ## [24.3.0] - 2024-10-13
 
 ### Changed
@@ -33,8 +37,6 @@ for emergencies).
 - Added testing against Python 3.13 (beta).
 
 - Removed support for Python 3.8.
-
-- Fix ability to make zone deligation
 
 ## [24.1.0] - 2024-02-09
 

--- a/src/plugins/modules/zone.py
+++ b/src/plugins/modules/zone.py
@@ -159,7 +159,7 @@ options:
             Only used when O(properties.kind=Native), O(properties.kind=Master),
             or O(properties.kind=Producer).
           - Only used when zone is being created (O(state=present) and zone is not present).
-          - SOA and NS records are not permitted.
+          - SOA records are not permitted.
         type: list
         elements: dict
         suboptions:
@@ -1438,7 +1438,7 @@ def main():
 
             if props["rrsets"]:
                 for rrset in props["rrsets"]:
-                    if rrset["type"] in ["SOA", "NS"]:
+                    if rrset["type"] in ["SOA"]:
                         module.fail_json(
                             msg=(
                                 f"'{rrset['type']}' type is not permitted in 'properties -> rrsets'"

--- a/workflow-support/test-zone-rrset.yml
+++ b/workflow-support/test-zone-rrset.yml
@@ -46,7 +46,7 @@
       vars:
         d1_rrset: "{{ lookup('dig_local', 't1.d1.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check for failure when rrset includes NS
+    - name: check zone creation with zone deligation
       kpfleming.powerdns_auth.zone:
         <<: *common
         name: d2.rrset.example.
@@ -59,10 +59,10 @@
             mname: localhost.
             rname: hostmaster.localhost.
           rrsets:
-            - name: d2.rrset.example.
+            - name: sub.d2.rrset.example.
               type: NS
               records:
-                - content: ns1.invalid.
+                - content: ns2.example.
       ignore_errors: true
       register: result
 
@@ -70,7 +70,7 @@
         quiet: true
         that:
           - result['exception'] is not defined
-          - result.failed
+          - result.changed
 
     - name: check for failure when rrset includes SOA
       kpfleming.powerdns_auth.zone:

--- a/workflow-support/test-zone-rrset.yml
+++ b/workflow-support/test-zone-rrset.yml
@@ -46,7 +46,7 @@
       vars:
         d1_rrset: "{{ lookup('dig_local', 't1.d1.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check zone creation with zone deligation
+    - name: check zone creation with zone delegation
       kpfleming.powerdns_auth.zone:
         <<: *common
         name: d2.rrset.example.


### PR DESCRIPTION
Hi, I'm quite a new contributer to ansible collections,

Thank you for creating this collection, very useful!

this seems to work to do subzone deligation for regular dns zones and reverse DNS deligation in my enviroment

I could probably open an issue first, but could you look if this is a workable solution

Regards from Torstein