### PR TITLE
Upgrade to v4 of CI image.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - id: details
       uses: kpfleming/composite-actions/image-details@v2
       with:
-        base_image: python:bookworm-main
+        base_image: python:v4-bookworm-main
     - id: preflight
       uses: kpfleming/composite-actions/ci-preflight@v2
       with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ansible-powerdns-auth
 
 <a href="https://opensource.org"><img height="150" align="left" src="https://opensource.org/files/OSIApprovedCropped.png" alt="Open Source Initiative Approved License logo"></a>
-[![CI](https://github.com/kpfleming/ansible-powerdns-auth/workflows/CI/badge.svg)](https://github.com/kpfleming/ansible-powerdns-auth/actions?query=workflow%3ACI)
+[![CI](https://github.com/kpfleming/ansible-powerdns-auth/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/kpfleming/ansible-powerdns-auth/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/release/python-3920/)
 [![License - Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-9400d3.svg)](https://spdx.org/licenses/Apache-2.0.html)
 [![Code Style and Quality - Ruff](https://img.shields.io/badge/Code%20Quality-Ruff-red.svg)](https://github.com/astral-sh/ruff)

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands=
     ruff check --output-format=full --fix --show-fixes src
     ansible-lint --fix all --strict --profile production -v
 
-[testenv:py{39,310,311,312,313}-ci-action]
+[testenv:py{39,310,311,312,313,314}-ci-action]
 deps=
     {[galaxy-setup]deps}
     ansible-core

--- a/workflow-support/make_ci_image.sh
+++ b/workflow-support/make_ci_image.sh
@@ -2,11 +2,6 @@
 
 set -ex
 
-# Arguments:
-#
-# 1: registry, name, and tag of base image
-# 2: registry, name, and tag of image to be created
-
 scriptdir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 containersrcdir="/__w/${GITHUB_REPOSITORY##*/}/${GITHUB_REPOSITORY##*/}"
 base_image=${1}; shift
@@ -14,11 +9,13 @@ image_name=${1}; shift
 
 pdns_build=(build-essential autoconf automake ragel bison flex libboost-all-dev pkg-config python3-venv libluajit-5.1-dev libssl-dev libsqlite3-dev sqlite3)
 pdns_run=(libsqlite3-0 libluajit-5.1-2)
+# remove these build deps once there are 'cffi' wheels for Python 3.14
+proj_build_deps=(gcc libffi-dev)
 lint_deps=(shellcheck)
 publish_deps=(yq)
 
 toxenvs=(lint-action ci-action publish-action)
-cimatrix=(py3{9,10,11,12,13})
+cimatrix=(py3{9,10,11,12,13,14})
 
 c=$(buildah from "${base_image}")
 
@@ -30,10 +27,9 @@ build_cmd_with_source() {
     buildah run --network host --volume "$(realpath "${scriptdir}/.."):${containersrcdir}" --workingdir "${containersrcdir}" "${c}" -- "$@"
 }
 
-build_cmd apt-get update --quiet=2
-build_cmd apt-get install --yes --quiet=2 "${pdns_build[@]}" "${pdns_run[@]}"
-build_cmd apt-get install --yes --quiet=2 "${lint_deps[@]}"
-build_cmd apt-get install --yes --quiet=2 "${publish_deps[@]}"
+build_cmd apt update --quiet=2
+build_cmd apt install --yes --quiet=2 "${pdns_build[@]}" "${pdns_run[@]}"
+build_cmd apt install --yes --quiet=2 "${proj_build_deps[@]}" "${lint_deps[@]}" "${publish_deps[@]}"
 
 for pdns_ver in "${@}"; do
     case "${pdns_ver}" in
@@ -53,22 +49,32 @@ for pdns_ver in "${@}"; do
     rm -rf "${pdns_dir}"
 done
 
+build_cmd uv tool install --python python3.13 --no-cache tox --with tox-uv
+
+build_cmd mkdir /tox
+buildah copy "${c}" "${scriptdir}/tox-config.ini" /tox/config.ini
+buildah config --env TOX_USER_CONFIG_FILE=/tox/config.ini "${c}"
+
 for env in "${toxenvs[@]}"; do
     case "${env}" in
 	ci-action)
 	    for py in "${cimatrix[@]}"; do
-		build_cmd_with_source tox exec -e "${py}-${env}" -- pip list
+		build_cmd_with_source tox exec -e "${py}-${env}" -- uv pip list
 	    done
 	;;
 	*)
-	    build_cmd_with_source tox exec -e "${env}" -- pip list
+	    build_cmd_with_source tox exec -e "${env}" -- uv pip list
 	;;
     esac
 done
 
-build_cmd apt-get remove --yes --purge "${pdns_build[@]}"
-build_cmd apt-get autoremove --yes --purge
-build_cmd apt-get clean autoclean
+build_cmd apt remove --yes --purge "${pdns_build[@]}"
+if [ -n "${proj_build_deps[*]}" ]
+then
+    build_cmd apt remove --yes --purge "${proj_build_deps[@]}"
+fi
+build_cmd apt autoremove --yes --purge
+build_cmd apt clean autoclean
 build_cmd sh -c "rm -rf /var/lib/apt/lists/*"
 
 build_cmd rm -rf /root/.cache

--- a/workflow-support/tox-config.ini
+++ b/workflow-support/tox-config.ini
@@ -1,0 +1,2 @@
+[tox]
+work_dir = /tox

--- a/workflow-support/versions.json
+++ b/workflow-support/versions.json
@@ -1,1 +1,1 @@
-versions={"pdns":["4.7", "4.8", "4.9", "master"], "python": ["py39", "py310", "py311", "py312", "py313"]}
+versions={"pdns":["4.7", "4.8", "4.9", "master"], "python": ["py39", "py310", "py311", "py312", "py313", "py314"]}


### PR DESCRIPTION
* Add testing against Python 3.14.

* Switch from apt-get to apt in make_ci_image script.

* Install tox and tox-uv using 'uv tool'.

* Install GCC and libffi-dev (needed until 'cffi' has wheels for Python 3.14).